### PR TITLE
Fix case sensitivity issue with difficult_words

### DIFF
--- a/test.py
+++ b/test.py
@@ -155,19 +155,19 @@ class Test_TextStat(unittest.TestCase):
     def test_difficult_words(self):
         result = textstat.difficult_words(self.long_test)
 
-        self.assertEqual(62, result)
+        self.assertEqual(49, result)
 
 
     def test_dale_chall_readability_score(self):
         score = textstat.dale_chall_readability_score(self.long_test)
 
-        self.assertEqual(7.35, score)
+        self.assertEqual(6.8, score)
 
 
     def test_gunning_fog(self):
         score = textstat.gunning_fog(self.long_test)
 
-        self.assertEqual(17.426666666666666, score)
+        self.assertEqual(16.028817204301074, score)
 
 
     def test_lix(self):

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+
+
 from __future__ import print_function
 from __future__ import division
 import pkg_resources
@@ -198,13 +201,12 @@ class textstatistics:
 
     @repoze.lru.lru_cache(maxsize=128)
     def difficult_words(self, text):
-        text_list = text.split()
+        text_list = re.findall("[\w\='‘’]+", text.lower())
         diff_words_set = set()
         for value in text_list:
             if value not in easy_word_set:
                 if self.syllable_count(value) > 1:
-                    if value not in diff_words_set:
-                        diff_words_set.add(value)
+                    diff_words_set.add(value)
         return len(diff_words_set)
 
     @repoze.lru.lru_cache(maxsize=128)


### PR DESCRIPTION
hello @shivam5992 :wave: !

This closes #31.

I opted to use the unicode characters `‘` and `’` directly in the source instead of using the escape sequences `\u2018` and `\u2019` as I thought it made it clearer which characters were being searched for. If you'd prefer the escapes sequences, let me know.

As suspected the changes caused some failing tests:

<details>
  <summary>Test output</summary>
  <p>

```plain
.......FF..F.........

======================================================================
FAIL: test_dale_chall_readability_score (test.Test_TextStat)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test.py", line 164, in test_dale_chall_readability_score
    self.assertEqual(7.35, score)
AssertionError: 7.35 != 6.8

======================================================================
FAIL: test_difficult_words (test.Test_TextStat)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test.py", line 158, in test_difficult_words
    self.assertEqual(62, result)
AssertionError: 62 != 49

======================================================================
FAIL: test_gunning_fog (test.Test_TextStat)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test.py", line 170, in test_gunning_fog
    self.assertEqual(17.426666666666666, score)
AssertionError: 17.426666666666666 != 16.028817204301074

----------------------------------------------------------------------

Ran 21 tests in 0.113s

FAILED (failures=3)
```
</p>
</details><br>

I've updated the tests to match the new 'correct' values. Although I suspect this might need revisiting at some point.

Finally, I removed the statement:

```python
if value not in diff_words_set:
```

As sets cannot have duplicates, I thought this check was redundant.
