### PR TITLE
Add version to module

### DIFF
--- a/textstat/__init__.py
+++ b/textstat/__init__.py
@@ -1,6 +1,9 @@
 from textstat.textstat import textstat
 
 
+__version__ = (0, 4, 1)
+
+
 for attribute in dir(textstat):
     if callable(getattr(textstat, attribute)):
         if not attribute.startswith("_"):


### PR DESCRIPTION
Adds `.__version__` to textstat at a module level.

```python
>>> import textstat
>>> textstat.__version__
(0, 4, 1)
```

closes #53 
