### PR TITLE
Semantic fixes

### DIFF
--- a/test.py
+++ b/test.py
@@ -70,6 +70,14 @@ class Test_TextStat(unittest.TestCase):
         self.assertEqual(2123, count_spaces)
 
 
+    def test_letter_count(self):
+        count = textstat.letter_count(self.long_test)
+        count_spaces = textstat.letter_count(self.long_test, ignore_spaces=False)
+
+        self.assertEqual(1688, count)
+        self.assertEqual(2061, count_spaces)
+
+
     def test_lexicon_count(self):
         count = textstat.lexicon_count(self.long_test)
         count_punc = textstat.lexicon_count(self.long_test, removepunct=False)

--- a/test.py
+++ b/test.py
@@ -113,7 +113,7 @@ class Test_TextStat(unittest.TestCase):
     def test_avg_letter_per_word(self):
         avg = textstat.avg_letter_per_word(self.long_test)
 
-        self.assertEqual(4.7, avg)
+        self.assertEqual(4.54, avg)
 
 
     def test_avg_sentence_per_word(self):
@@ -149,7 +149,7 @@ class Test_TextStat(unittest.TestCase):
     def test_coleman_liau_index(self):
         index = textstat.coleman_liau_index(self.long_test)
 
-        self.assertEqual(10.28, index)
+        self.assertEqual(9.35, index)
 
 
     def test_automated_readability_index(self):
@@ -191,7 +191,7 @@ class Test_TextStat(unittest.TestCase):
     def test_text_standard(self):
         standard = textstat.text_standard(self.long_test)
 
-        self.assertEqual("9th and 10th grade", standard)
+        self.assertEqual("14th and 15th grade", standard)
 
         standard = textstat.text_standard(self.short_test)
 

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -25,6 +25,7 @@ def legacy_round(number, points=0):
     p = 10 ** points
     return float(math.floor((number * p) + math.copysign(0.5, number))) / p
 
+
 def get_grade_suffix(grade):
     """
     Select correct ordinal suffix
@@ -32,6 +33,7 @@ def get_grade_suffix(grade):
     ordinal_map = {1: 'st', 2: 'nd', 3: 'rd'}
     teens_map = {11: 'th', 12: 'th', 13: 'th'}
     return teens_map.get(grade % 100, ordinal_map.get(grade % 10, 'th'))
+
 
 class textstatistics:
     text_encoding = "utf-8"

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -47,6 +47,16 @@ class textstatistics:
             text = text.replace(" ", "")
         return len(text)
 
+    @repoze.lru.lru_cache(maxsize=128)
+    def letter_count(self, text, ignore_spaces=True):
+        """
+        Function to return total letter amount in a text,
+        pass the following parameter `ignore_spaces = False`
+        to ignore whitespaces
+        """
+        if ignore_spaces:
+            text = text.replace(" ", "")
+        return len(self.remove_punctuation(text))
 
     @staticmethod
     def remove_punctuation(text):

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -14,7 +14,6 @@ import pkg_resources
 import repoze.lru
 from pyphen import Pyphen
 
-exclude = list(string.punctuation)
 
 easy_word_set = set([
     ln.decode('utf-8').strip() for ln in
@@ -48,13 +47,18 @@ class textstatistics:
             text = text.replace(" ", "")
         return len(text)
 
+
+    @staticmethod
+    def remove_punctuation(text):
+        return ''.join(ch for ch in text if ch not in string.punctuation)
+
     @repoze.lru.lru_cache(maxsize=128)
     def lexicon_count(self, text, removepunct=True):
         """
         Function to return total lexicon (words in lay terms) counts in a text
         """
         if removepunct:
-            text = ''.join(ch for ch in text if ch not in exclude)
+            text = self.remove_punctuation(text)
         count = len(text.split())
         return count
 
@@ -69,7 +73,7 @@ class textstatistics:
             text = text.decode(self.text_encoding)
 
         text = text.lower()
-        text = "".join(x for x in text if x not in exclude)
+        text = self.remove_punctuation(text)
 
         if not text:
             return 0

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -126,10 +126,19 @@ class textstatistics:
             return 0.0
 
     @repoze.lru.lru_cache(maxsize=128)
-    def avg_letter_per_word(self, text):
+    def avg_character_per_word(self, text):
         try:
             letters_per_word = float(
                 self.char_count(text) / self.lexicon_count(text))
+            return legacy_round(letters_per_word, 2)
+        except ZeroDivisionError:
+            return 0.0
+
+    @repoze.lru.lru_cache(maxsize=128)
+    def avg_letter_per_word(self, text):
+        try:
+            letters_per_word = float(
+                self.letter_count(text) / self.lexicon_count(text))
             return legacy_round(letters_per_word, 2)
         except ZeroDivisionError:
             return 0.0


### PR DESCRIPTION
This address some semantic issues by adding 2 new methods: `avg_character_per_word` and `letter_count`.

The current `avg_letter_per_word` was using a character count, which included punctuation. This has now been expanded so the surface area is:
```python
textstat.char_count
textstat.avg_character_per_word
textstat.letter_count
textstat.avg_letter_per_word
```

closes #67 