### PR TITLE
Make setup.py compatible with Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+from io import open
 
 setup(
     name='textstat',


### PR DESCRIPTION
In Python 2.7, the open function doesn't accept an `encoding` parameter.  For backwards compatibility you can replace the built-in `open()` function with `open()` from the `io` module.  See https://docs.python.org/3/howto/pyporting.html