### PR TITLE
Issue #75: SPACHE readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *egg*
 .idea/
 venv
+.vscode
+.DS_Store

--- a/test.py
+++ b/test.py
@@ -238,4 +238,4 @@ class Test_TextStat(unittest.TestCase):
         textstat.text_standard(u"ありがとうございます")
     def test_spache_readability(self):
         #"spache readability"
-        self.assertEqual(textstat.spache_readability(self.easy_text), 3)
+        self.assertEqual(textstat.spache_readability(self.easy_text, False), 2)

--- a/test.py
+++ b/test.py
@@ -61,6 +61,16 @@ class Test_TextStat(unittest.TestCase):
                           "place a higher priority on playing games in their "
                           "lives")
 
+        self.easy_text = ("Anna and her family love doing puzzles. Anna is best at little puzzles. "
+                          "Anna and her brother work on medium size puzzles together. Anna's Brother "
+                          "likes puzzles with cars in them."
+                          "When the whole family does a puzzle, they do really big puzzles. "
+                          "It can take them a week to finish a really big puzzle. "
+                          "Last year they did a puzzle with 500 pieces! "
+                          "Anna tries to finish one small puzzle a day by her. Her puzzles have about 50 pieces. "
+                          "They all glue their favorite puzzles together and frame them. The puzzles look so nice "
+                          "on the wall.")
+
 
     def test_char_count(self):
         count = textstat.char_count(self.long_test)
@@ -226,3 +236,6 @@ class Test_TextStat(unittest.TestCase):
             "\u3042\u308a\u304c\u3068\u3046\u3054\u3056\u3044\u307e\u3059")
 
         textstat.text_standard(u"ありがとうございます")
+    def test_spache_readability(self):
+        #"spache readability"
+        self.assertEqual(textstat.spache_readability(self.easy_text), 3)

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -411,7 +411,9 @@ class textstatistics:
         #find the average sentance length
         asl = total_no_of_words/count_of_sentences
         text_set = set(self.remove_punctuation(text).split())
+        #Count the number of words in the sample text that are not found on the Spache Revised Word List
         count_of_words_not_in_spache = len(text_set - easy_word_set)
+        #Percentage of Difficult Words (PDW)
         pdw = (count_of_words_not_in_spache/total_no_of_words) * 100
         if float_output is False:
            return int((0.141 * asl) + (0.086 * pdw) + 0.839)

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -317,6 +317,27 @@ class textstatistics:
         return legacy_round(rix, 2)
 
     @repoze.lru.lru_cache(maxsize=128)
+    def spache_readability(self, text, float_output=True):
+        """
+        Function to calculate SPACHE readability formula for young readers.
+        I/P - a text
+        O/P - an int Spache Readability Index/Grade Level
+        """
+        #Count the total number of words in the sample text
+        total_no_of_words = self.lexicon_count(text)
+        #Count the number of sentences in the sample text
+        count_of_sentences = self.sentence_count(text)
+        #find the average sentance length
+        asl = total_no_of_words/count_of_sentences
+        #Percentage of Difficult Words (PDW)
+        pdw = (self.difficult_words(text)/total_no_of_words) * 100
+        spache = (0.141 * asl) + (0.086 * pdw) + 0.839
+        if not float_output:
+           return int(spache)
+        else:
+            return spache
+
+    @repoze.lru.lru_cache(maxsize=128)
     def text_standard(self, text, float_output=None):
 
         grade = []
@@ -397,30 +418,6 @@ class textstatistics:
                 lower_score, get_grade_suffix(lower_score),
                 upper_score, get_grade_suffix(upper_score)
             )
-    @repoze.lru.lru_cache(maxsize=128)
-    def spache_readability(self, text, float_output=False):
-        """
-        Function to calculate SPACHE readability formula for young readers.
-        I/P - a text
-        O/P - an int Spache Readability Index/Grade Level
-        """
-        #Count the total number of words in the sample text
-        total_no_of_words = self.lexicon_count(text)
-        #Count the number of sentences in the sample text
-        count_of_sentences = self.sentence_count(text)
-        #find the average sentance length
-        asl = total_no_of_words/count_of_sentences
-        text_set = set(self.remove_punctuation(text).split())
-        #Count the number of words in the sample text that are not found on the Spache Revised Word List
-        count_of_words_not_in_spache = len(text_set - easy_word_set)
-        #Percentage of Difficult Words (PDW)
-        pdw = (count_of_words_not_in_spache/total_no_of_words) * 100
-        if float_output is False:
-           return int((0.141 * asl) + (0.086 * pdw) + 0.839)
-        else:
-            return (0.141 * asl) + (0.086 * pdw) + 0.839
-
-
 
 
 textstat = textstatistics()

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -9,7 +9,6 @@ import re
 import math
 import operator
 from collections import Counter
-
 import pkg_resources
 import repoze.lru
 from pyphen import Pyphen
@@ -398,6 +397,28 @@ class textstatistics:
                 lower_score, get_grade_suffix(lower_score),
                 upper_score, get_grade_suffix(upper_score)
             )
+    @repoze.lru.lru_cache(maxsize=128)
+    def spache_readability(self, text, float_output=False):
+        """
+        Function to calculate SPACHE readability formula for young readers.
+        I/P - a text
+        O/P - an int Spache Readability Index/Grade Level
+        """
+        #Count the total number of words in the sample text
+        total_no_of_words = self.lexicon_count(text)
+        #Count the number of sentences in the sample text
+        count_of_sentences = self.sentence_count(text)
+        #find the average sentance length
+        asl = total_no_of_words/count_of_sentences
+        text_set = set(self.remove_punctuation(text).split())
+        count_of_words_not_in_spache = len(text_set - easy_word_set)
+        pdw = (count_of_words_not_in_spache/total_no_of_words) * 100
+        if float_output is False:
+           return int((0.141 * asl) + (0.086 * pdw) + 0.839)
+        else:
+            return (0.141 * asl) + (0.086 * pdw) + 0.839
+
+
 
 
 textstat = textstatistics()


### PR DESCRIPTION
#75 
Added function for SPACHE readability for young adults.
Tested this sample text on this [SPACHE Calculator](http://www.readabilityformulas.com/free-readability-formula-tests.php) as well.

![image](https://user-images.githubusercontent.com/15629249/55654628-eee70b80-57bf-11e9-86c4-9373946ccb4d.png)

Here are the unit test case results, 3 other functions fails test.

```======================================================================
FAIL: test_gunning_fog (test.Test_TextStat)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/agupta/MyProjects/textstat/test.py", line 192, in test_gunning_fog
    self.assertEqual(14.59, score)
AssertionError: 14.59 != 11.26

======================================================================
FAIL: test_lexicon_count (test.Test_TextStat)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/agupta/MyProjects/textstat/test.py", line 96, in test_lexicon_count
    self.assertEqual(375, count_punc)
AssertionError: 375 != 376

======================================================================
FAIL: test_text_standard (test.Test_TextStat)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/agupta/MyProjects/textstat/test.py", line 210, in test_text_standard
    self.assertEqual("14th and 15th grade", standard)
AssertionError: '14th and 15th grade' != '9th and 10th grade'
- 14th and 15th grade
? ^^        ^
+ 9th and 10th grade
? ^        ^


----------------------------------------------------------------------
Ran 25 tests in 0.091s

FAILED (failures=3)
