### PR TITLE
Return a list of difficult words instead of just length

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,4 +10,4 @@ Pyphen = "*"
 [dev-packages]
 pycodestyle = "*"
 pytest = "*"
-
+ipython = "*"

--- a/test.py
+++ b/test.py
@@ -5,7 +5,6 @@
 
 import textstat
 
-
 short_test = "Cool dogs wear da sunglasses."
 
 long_test = (
@@ -198,7 +197,55 @@ def test_difficult_words():
     textstat.set_lang("en_US")
     result = textstat.difficult_words(long_test)
 
-    assert result == 49
+    assert set(result) == set(['exist',
+                      'allows',
+                      'stimulating',
+                      'release',
+                      'reasons',
+                      'aspect',
+                      'enables',
+                      'creative',
+                      'keeping',
+                      'discuss',
+                      'enjoying',
+                      'activities',
+                      'mastermind',
+                      'couple',
+                      'relationships',
+                      'relaxing',
+                      'purchase',
+                      'backgammon',
+                      'interpersonal',
+                      'monopoly',
+                      'competition',
+                      'enjoys',
+                      'balanced',
+                      'sadly',
+                      "joneses'",
+                      'relax',
+                      'threatening',
+                      'interact',
+                      'researched',
+                      'environment',
+                      'memorable',
+                      'coworkers',
+                      'integral',
+                      'higher',
+                      'playing',
+                      'weekends',
+                      'enriched',
+                      'ladders',
+                      'comfortable',
+                      'unwind',
+                      'development',
+                      'neglect',
+                      'working',
+                      'cupboards',
+                      'couples',
+                      'tension',
+                      'priority',
+                      'reflect',
+                      'received'])
 
 
 def test_dale_chall_readability_score():

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -287,7 +287,7 @@ class textstatistics:
             if value not in easy_word_set:
                 if self.syllable_count(value) >= syllable_threshold:
                     diff_words_set.add(value)
-        return len(diff_words_set)
+        return list(diff_words_set)
 
     @repoze.lru.lru_cache(maxsize=128)
     def dale_chall_readability_score(self, text):

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -292,7 +292,7 @@ class textstatistics:
     @repoze.lru.lru_cache(maxsize=128)
     def dale_chall_readability_score(self, text):
         word_count = self.lexicon_count(text)
-        count = word_count - self.difficult_words(text)
+        count = word_count - len(self.difficult_words(text))
 
         try:
             per = float(count) / float(word_count) * 100
@@ -314,8 +314,8 @@ class textstatistics:
         try:
             syllable_threshold = self.__get_lang_cfg("syllable_threshold")
             per_diff_words = (
-                (self.difficult_words(text,
-                                      syllable_threshold=syllable_threshold)
+                (len(self.difficult_words(text,
+                                      syllable_threshold=syllable_threshold))
                     / self.lexicon_count(text) * 100))
 
             grade = 0.4 * (self.avg_sentence_length(text) + per_diff_words)
@@ -364,7 +364,7 @@ class textstatistics:
         total_no_of_words = self.lexicon_count(text)
         count_of_sentences = self.sentence_count(text)
         asl = total_no_of_words/count_of_sentences
-        pdw = (self.difficult_words(text)/total_no_of_words) * 100
+        pdw = (len(self.difficult_words(text))/total_no_of_words) * 100
         spache = (0.141 * asl) + (0.086 * pdw) + 0.839
         if not float_output:
             return int(spache)
@@ -381,7 +381,7 @@ class textstatistics:
         total_no_of_words = self.lexicon_count(text)
         count_of_sentences = self.sentence_count(text)
         asl = total_no_of_words/count_of_sentences
-        pdw = (self.difficult_words(text)/total_no_of_words) * 100
+        pdw = (len(self.difficult_words(text))/total_no_of_words) * 100
         raw_score = 0.1579 * (pdw) + 0.0496 * asl
         adjusted_score = raw_score
         if raw_score > 0.05:


### PR DESCRIPTION
This still gives the user the control to fetch the total difficult words with,

```python
>>>len(textstat.difficult_words(text=text_to_analyze))
```

🙂 Makes this feature more useful since they can use it later for further processing with the difficult words!