### PR TITLE
refs #76 added reading time

### DIFF
--- a/test.py
+++ b/test.py
@@ -286,7 +286,7 @@ def test_reading_time():
     textstat.set_lang("en_US")
     score = textstat.reading_time(long_test)
 
-    assert score == 25678.12
+    assert score == 0.43
 
 
 def test_lru_caching():

--- a/test.py
+++ b/test.py
@@ -282,6 +282,13 @@ def test_text_standard():
     assert standard == "2nd and 3rd grade"
 
 
+def test_reading_time():
+    textstat.set_lang("en_US")
+    score = textstat.reading_time(long_test)
+
+    assert score == 25678.12
+
+
 def test_lru_caching():
     textstat.set_lang("en_US")
     # Clear any cache

--- a/test.py
+++ b/test.py
@@ -286,7 +286,7 @@ def test_reading_time():
     textstat.set_lang("en_US")
     score = textstat.reading_time(long_test)
 
-    assert score == 0.43
+    assert score == 25.68
 
 
 def test_lru_caching():

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -98,6 +98,7 @@ class textstatistics:
         self.spache_readability._cache.clear()
         self.dale_chall_readability_score_v2._cache.clear()
         self.text_standard._cache.clear()
+        self.reading_time._cache.clear()
 
     @repoze.lru.lru_cache(maxsize=128)
     def char_count(self, text, ignore_spaces=True):
@@ -523,6 +524,19 @@ class textstatistics:
                 lower_score, get_grade_suffix(lower_score),
                 upper_score, get_grade_suffix(upper_score)
             )
+
+    @repoze.lru.lru_cache(maxsize=128)
+    def reading_time(self, text, ms_per_char=14.69):
+        """
+        Function to calculate reading time based on Vera Demberg and Frank Keller (2008)
+        I/P - a text
+        O/P - reading time in millisecond
+        """
+        words = text.split()
+        nchars = map(len, words)
+        rt_per_word = map(lambda nchar: nchar * ms_per_char, nchars)
+        reading_time = sum(list(rt_per_word))
+        return legacy_round(reading_time, 2)
 
     def __get_lang_cfg(self, key):
         default = langs.get("en")

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -528,7 +528,7 @@ class textstatistics:
     @repoze.lru.lru_cache(maxsize=128)
     def reading_time(self, text, ms_per_char=14.69):
         """
-        Function to calculate reading time based on Vera Demberg and Frank Keller (2008)
+        Function to calculate reading time (Demberg & Keller, 2008)
         I/P - a text
         O/P - reading time in millisecond
         """

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -526,17 +526,25 @@ class textstatistics:
             )
 
     @repoze.lru.lru_cache(maxsize=128)
-    def reading_time(self, text, ms_per_char=14.69):
+    def reading_time(self, text, unit="minute", ms_per_char=14.69):
         """
         Function to calculate reading time (Demberg & Keller, 2008)
         I/P - a text
-        O/P - reading time in millisecond
+        O/P - reading time in minute
         """
         words = text.split()
         nchars = map(len, words)
         rt_per_word = map(lambda nchar: nchar * ms_per_char, nchars)
         reading_time = sum(list(rt_per_word))
-        return legacy_round(reading_time, 2)
+
+        ms_to_unit = {"second": lambda ms: ms / 1000,
+                      "minute": lambda ms: ms / 1000 / 60,
+                      "hour": lambda ms: ms / 1000 / 60 / 60}
+
+        try:
+            return legacy_round(ms_to_unit[unit](reading_time), 2)
+        except KeyError:
+            print("'{}' is an invalid keyword argument for this function".format(unit))
 
     def __get_lang_cfg(self, key):
         default = langs.get("en")

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -526,25 +526,18 @@ class textstatistics:
             )
 
     @repoze.lru.lru_cache(maxsize=128)
-    def reading_time(self, text, unit="minute", ms_per_char=14.69):
+    def reading_time(self, text, ms_per_char=14.69):
         """
         Function to calculate reading time (Demberg & Keller, 2008)
         I/P - a text
-        O/P - reading time in minute
+        O/P - reading time in second
         """
         words = text.split()
         nchars = map(len, words)
         rt_per_word = map(lambda nchar: nchar * ms_per_char, nchars)
         reading_time = sum(list(rt_per_word))
 
-        ms_to_unit = {"second": lambda ms: ms / 1000,
-                      "minute": lambda ms: ms / 1000 / 60,
-                      "hour": lambda ms: ms / 1000 / 60 / 60}
-
-        try:
-            return legacy_round(ms_to_unit[unit](reading_time), 2)
-        except KeyError:
-            print("'{}' is an invalid keyword argument for this function".format(unit))
+        return legacy_round(reading_time/1000, 2)
 
     def __get_lang_cfg(self, key):
         default = langs.get("en")


### PR DESCRIPTION
I added a function that calculates reading time based on this article[1]. They reported that the coefficient for `word length`(or `nchar`) is around 29.64. So, the function first multiplies the `nchar` and 29.64 milliseconds for each word. For example, if a word has 4 characters, it will take 118.56 ms (4 * 29.64) to read the word. This makes a list of reading time for each word. The function then sums up the list, returning the reading time of the given text.

[1] Demberg, V., & Keller, F. (2008). Data from eye-tracking corpora as evidence for theories of syntactic processing complexity. Cognition, 109(2), 193-210.