### PR TITLE
Add new contribute section to docs sidebar

### DIFF
--- a/docs/_templates/contribute.html
+++ b/docs/_templates/contribute.html
@@ -1,0 +1,19 @@
+<h3 style="margin-top: 10px;">
+Contribute
+</h3>
+
+<p>Help improve this documentation! If you find something that needs to be
+updated, open a pull request.</p>
+
+<button id="contribute-button" style="font-family: Georgia, serif; font-size: 1em; padding: 0.4em; border: 1px solid #CCC; width:100%; cursor: pointer;">
+   <svg style="padding-right: 0.25em" version="1.1" width="12" height="12" viewBox="0 0 16 16" aria-hidden="true"><path fill-rule="evenodd" d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"></path></svg>
+    Make contribution
+</button>
+
+
+<script>
+    document.getElementById('contribute-button').addEventListener('click', function() {
+        let page = window.location.pathname.split('/').pop().split('.').shift();
+        window.open(`https://github.com/shivam5992/textstat/edit/master/docs/${page}.rst`)
+    })
+</script>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,12 +9,17 @@ releases_unstable_prehistory = True
 
 html_theme = 'alabaster'
 
+templates_path = [
+    '_templates',
+]
+
 html_sidebars = {
     '**': [
         'about.html',
         'navigation.html',
         'relations.html',
         'searchbox.html',
+        'contribute.html',
     ]
 }
 


### PR DESCRIPTION
Inspired by the [GitHub docs contribute button](https://github.blog/2020-10-07-github-docs-are-now-open-source/#start-contributing-today), this adds a "Make contribution" button to the sidebar of the docs on readthedocs.

![image](https://user-images.githubusercontent.com/13941027/95454143-f31b5880-0963-11eb-9ec4-0e5d4a20d044.png)
