### PR TITLE
Performance improvements for difficult word checks

### DIFF
--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -319,21 +319,17 @@ class textstatistics:
 
     @lru_cache(maxsize=128)
     def difficult_words_list(self, text, syllable_threshold=2):
-        text_list = re.findall(r"[\w\='‘’]+", text.lower())
-        diff_words_set = set()
-        for value in text_list:
-            if self.is_difficult_word(value, syllable_threshold):
-                diff_words_set.add(value)
-        return list(diff_words_set)
+        words = set(re.findall(r"[\w\='‘’]+", text.lower()))
+        diff_words = [word for word in words if self.is_difficult_word(word, syllable_threshold)]
+        return diff_words
 
     @lru_cache(maxsize=128)
     def is_difficult_word(self, word, syllable_threshold=2):
         easy_word_set = self.__get_lang_easy_words()
-        syllables = self.syllable_count(word)
-
-        if word in easy_word_set or syllables < syllable_threshold:
+        if word in easy_word_set:
             return False
-
+        if self.syllable_count(word) < syllable_threshold:
+            return False
         return True
 
     @lru_cache(maxsize=128)

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -72,6 +72,7 @@ def get_grade_suffix(grade):
 class textstatistics:
     __lang = "en_US"
     text_encoding = "utf-8"
+    __easy_word_sets = {}
 
     def __init__(self):
         self.set_lang(self.__lang)
@@ -613,27 +614,30 @@ class textstatistics:
         return self.__lang.split("_")[0]
 
     def __get_lang_easy_words(self):
-        try:
-            easy_word_set = {
-                ln.decode("utf-8").strip()
-                for ln in pkg_resources.resource_stream(
-                    "textstat",
-                    f"resources/{self.__get_lang_root()}/easy_words.txt",
+        lang = self.__get_lang_root()
+        if lang not in self.__easy_word_sets:
+            try:
+                easy_word_set = {
+                    ln.decode("utf-8").strip()
+                    for ln in pkg_resources.resource_stream(
+                        "textstat",
+                        f"resources/{lang}/easy_words.txt",
+                    )
+                }
+            except FileNotFoundError:
+                warnings.warn(
+                    "There is no easy words vocabulary for "
+                    f"{self.__lang}, using english.",
+                    Warning,
                 )
-            }
-        except FileNotFoundError:
-            warnings.warn(
-                "There is no easy words vocabulary for "
-                f"{self.__lang}, using english.",
-                Warning,
-            )
-            easy_word_set = {
-                ln.decode("utf-8").strip()
-                for ln in pkg_resources.resource_stream(
-                    "textstat", "resources/en/easy_words.txt"
-                )
-            }
-        return easy_word_set
+                easy_word_set = {
+                    ln.decode("utf-8").strip()
+                    for ln in pkg_resources.resource_stream(
+                        "textstat", "resources/en/easy_words.txt"
+                    )
+                }
+            self.__easy_word_sets[lang] = easy_word_set
+        return self.__easy_word_sets[lang]
 
 
 textstat = textstatistics()

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -73,6 +73,9 @@ class textstatistics:
     __lang = "en_US"
     text_encoding = "utf-8"
 
+    def __init__(self):
+        self.set_lang(self.__lang)
+
     def _cache_clear(self):
         caching_methods = [
             method for method in dir(self)
@@ -85,6 +88,7 @@ class textstatistics:
 
     def set_lang(self, lang):
         self.__lang = lang
+        self.pyphen = Pyphen(lang=self.__lang)
         self._cache_clear()
 
     @lru_cache(maxsize=128)
@@ -146,10 +150,9 @@ class textstatistics:
         if not text:
             return 0
 
-        dic = Pyphen(lang=self.__lang)
         count = 0
         for word in text.split(' '):
-            word_hyphenated = dic.inserted(word)
+            word_hyphenated = self.pyphen.inserted(word)
             count += max(1, word_hyphenated.count("-") + 1)
         return count
 

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -73,6 +73,7 @@ class textstatistics:
     __lang = "en_US"
     text_encoding = "utf-8"
     __easy_word_sets = {}
+    __punctuation_regex = re.compile(f'[{re.escape(string.punctuation)}]')
 
     def __init__(self):
         self.set_lang(self.__lang)
@@ -114,9 +115,9 @@ class textstatistics:
             text = text.replace(" ", "")
         return len(self.remove_punctuation(text))
 
-    @staticmethod
-    def remove_punctuation(text):
-        return ''.join(ch for ch in text if ch not in string.punctuation)
+    @classmethod
+    def remove_punctuation(cls, text):
+        return cls.__punctuation_regex.sub('', text)
 
     @lru_cache(maxsize=128)
     def lexicon_count(self, text, removepunct=True):
@@ -153,8 +154,7 @@ class textstatistics:
 
         count = 0
         for word in text.split(' '):
-            word_hyphenated = self.pyphen.inserted(word)
-            count += max(1, word_hyphenated.count("-") + 1)
+            count += len(self.pyphen.positions(word)) + 1
         return count
 
     @lru_cache(maxsize=128)

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -321,7 +321,8 @@ class textstatistics:
     @lru_cache(maxsize=128)
     def difficult_words_list(self, text, syllable_threshold=2):
         words = set(re.findall(r"[\w\='‘’]+", text.lower()))
-        diff_words = [word for word in words if self.is_difficult_word(word, syllable_threshold)]
+        diff_words = [word for word in words
+                      if self.is_difficult_word(word, syllable_threshold)]
         return diff_words
 
     @lru_cache(maxsize=128)


### PR DESCRIPTION
The functions which use `difficult_words` are crazy slow. Specifically `gunning_fog` takes several seconds to run on a large article of text!

This PR makes several changes:
- Only use one pyphen instance instead of recreating it on every call to `syllable_count` which makes pyphen reload its internal files.
- Cache easy word lists instead of reloading them on every call to `is_difficult_word`. 
- Don't calculate syllables in `is_difficult_word` if the word is already in the easy list.
- Deduplicate words in `difficult_words_list` before checking if they are difficult instead of afterwards.

The improvements from this for `gunning_fog` are vast, at least an order of magnitude. `dale_chall_readability_score` is also much faster. Overall runtime for tests is halved.
