### PR TITLE
Ignore all and splity by all whitespace characters where expected

### DIFF
--- a/test.py
+++ b/test.py
@@ -186,7 +186,7 @@ def test_char_count():
         long_test, ignore_spaces=False
     )
 
-    assert count == 1750
+    assert count == 1748
     assert count_spaces == 2123
 
 
@@ -197,7 +197,7 @@ def test_letter_count():
         long_test, ignore_spaces=False
     )
 
-    assert count == 1688
+    assert count == 1686
     assert count_spaces == 2061
 
 
@@ -214,7 +214,7 @@ def test_syllable_count():
     textstat.set_lang("en_US")
     count = textstat.syllable_count(long_test)
 
-    assert count == 521
+    assert count == 519
 
 
 def test_sentence_count():
@@ -249,7 +249,7 @@ def test_avg_letter_per_word():
     textstat.set_lang("en_US")
     avg = textstat.avg_letter_per_word(long_test)
 
-    assert avg == 4.54
+    assert avg == 4.53
 
 
 def test_avg_sentence_per_word():
@@ -273,7 +273,7 @@ def test_flesch_reading_ease():
     textstat.set_lang("es_ES")
     score = textstat.flesch_reading_ease(long_test)
 
-    assert score == 84.37
+    assert score == 85.33
 
     textstat.set_lang("fr_FR")
     score = textstat.flesch_reading_ease(long_test)
@@ -283,7 +283,7 @@ def test_flesch_reading_ease():
     textstat.set_lang("it_IT")
     score = textstat.flesch_reading_ease(long_test)
 
-    assert score == 89.27
+    assert score == 90.11
 
     textstat.set_lang("nl_NL")
     score = textstat.flesch_reading_ease(long_test)
@@ -321,7 +321,7 @@ def test_coleman_liau_index():
     textstat.set_lang("en_US")
     index = textstat.coleman_liau_index(long_test)
 
-    assert index == 9.35
+    assert index == 9.29
 
 
 def test_automated_readability_index():

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -101,7 +101,7 @@ class textstatistics:
         to ignore whitespaces
         """
         if ignore_spaces:
-            text = text.replace(" ", "")
+            text = re.sub("\s", "", text)
         return len(text)
 
     @lru_cache(maxsize=128)
@@ -112,7 +112,7 @@ class textstatistics:
         to ignore whitespaces
         """
         if ignore_spaces:
-            text = text.replace(" ", "")
+            text = re.sub("\s", "", text)
         return len(self.remove_punctuation(text))
 
     @classmethod
@@ -153,7 +153,7 @@ class textstatistics:
             return 0
 
         count = 0
-        for word in text.split(' '):
+        for word in text.split():
             count += len(self.pyphen.positions(word)) + 1
         return count
 


### PR DESCRIPTION
The method syllable_count used split(' ') and not split()
and thus didn't split by newline characters.
The methods char_count and letter_count didn't substitute newlines. Now
a regex for all whitespace characters is used.

Fix #158