### PR TITLE
Run jobs unless cancelled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,16 @@ jobs:
         pipenv install --dev
 
     - name: Check code spelling
+      if: ${{ !cancelled() }}
       run: |
         pipenv run codespell -L paket --skip=./textstat/resources/**/easy_words.txt,./build/*,./textstat.egg-info/*
 
     - name: Lint with flake8
+      if: ${{ !cancelled() }}
       run: |
         pipenv run flake8 . --exclude=build/
 
     - name: Test with pytest
+      if: ${{ !cancelled() }}
       run: |
         pipenv run pytest test.py


### PR DESCRIPTION
This updates the Github workflow to run the test, lint, and spell jobs even if the others failed.