### PR TITLE
Keep apostrophe even if contraction is at the end of a string

### DIFF
--- a/.codespellignorelines
+++ b/.codespellignorelines
@@ -1,1 +1,1 @@
-sure youre really just removing the characters you want to remove
+sure youre really just removing the characters you want to remove Didnt

--- a/test.py
+++ b/test.py
@@ -12,21 +12,21 @@ punct_text = """
 I said: 'This is a test sentence to test the remove_punctuation function.
 It's short and not the work of a singer-songwriter. But it'll suffice.'
 Your answer was: "I don't know. If I were you I'd write a test; just to make
-sure, you're really just removing the characters you want to remove!"
+sure, you're really just removing the characters you want to remove!" Didn't
 """
 
 punct_text_result_w_apostr = """
 I said This is a test sentence to test the remove_punctuation function
 It's short and not the work of a singersongwriter But it'll suffice
 Your answer was I don't know If I were you I'd write a test just to make
-sure you're really just removing the characters you want to remove
+sure you're really just removing the characters you want to remove Didn't
 """
 
 punct_text_result_wo_apostr = """
 I said This is a test sentence to test the remove_punctuation function
 Its short and not the work of a singersongwriter But itll suffice
 Your answer was I dont know If I were you Id write a test just to make
-sure youre really just removing the characters you want to remove
+sure youre really just removing the characters you want to remove Didnt
 """
 
 long_test = (

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -160,7 +160,7 @@ class textstatistics:
         else:
             # replace single quotation marks with double quotation marks but
             # keep apostrophes in contractions
-            text = re.sub(r"\'(?!t\W|s\W|ve\W|ll\W|re\W|d\W)", '"', text)
+            text = re.sub(r"\'(?![tsd]\b|ve\b|ll\b|re\b)", '"', text)
             # remove all punctuation except apostrophes
             punctuation_regex = r"[^\w\s\']"
 


### PR DESCRIPTION
Previously, if a contraction was at the end of a string ("I wasn't"),
the apostrophe was removed, even if the __rm_apostrophe attribute was
set to false.