### PR TITLE
Add Python version 3.10 to test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Quotes have been added around the version numbers to mitigate the Python 3.1 problem aka Python Y2K

test (3.10) check passed during a test PR to my fork: https://github.com/lclarko/textstat/pull/1

https://github.com/actions/virtual-environments/issues/4226#issuecomment-937787327