### PR TITLE
test_rix score fix

### DIFF
--- a/test.py
+++ b/test.py
@@ -449,7 +449,7 @@ def test_rix():
     textstat.set_lang("en_US")
     score = textstat.rix(long_test)
 
-    assert score == 4.82
+    assert score == 4.59
 
 
 def test_text_standard():


### PR DESCRIPTION
Pull 178 implemented the removal of punctuation in the rix function, as per the formula's original authors recommendation.

The corresponding assert statement in the test for this function now has a different value.

This PR addresses this change.