### PR TITLE
fix: clamp text_standard grade levels to sensible bounds

### DIFF
--- a/tests/backend/resources.py
+++ b/tests/backend/resources.py
@@ -236,3 +236,10 @@ GERMAN_SAMPLE_B = """
     Alle Parteien widmen dem Thema rein quantitativ betrachtet nennenswerte
     Aufmerksamkeit, die Grünen wenig überraschend am meisten.
     """
+
+# Extreme readability tests (for bounds clamping)
+VERY_SIMPLE_TEXT = "I am simple text"
+VERY_COMPLEX_TEXT = (
+    "Epistemological paradigms invariably necessitate hermeneutic scrutiny "
+    "of phenomenological constructs through dialectical methodologies."
+)

--- a/tests/textstat/test_text_standard.py
+++ b/tests/textstat/test_text_standard.py
@@ -27,7 +27,7 @@ def test_text_standard(text: str, float_output: bool, expected: float | str) -> 
 
 
 # Test that grade level bounds are clamped (issue #205)
-VERY_SIMPLE_TEXT = "I am"
+VERY_SIMPLE_TEXT = "I am simple"
 VERY_COMPLEX_TEXT = (
     "Epistemological paradigms invariably necessitate hermeneutic scrutiny "
     "of phenomenological constructs through dialectical methodologies."

--- a/tests/textstat/test_text_standard.py
+++ b/tests/textstat/test_text_standard.py
@@ -8,8 +8,9 @@ from ..backend import resources
 @pytest.mark.parametrize(
     "text, float_output, expected",
     [
-        (resources.EMPTY_STR, True, 0.0),
-        (resources.EMPTY_STR, False, "-1th and 0th grade"),
+        # Empty/simple text now clamps to minimum grade level (1.0)
+        (resources.EMPTY_STR, True, 1.0),
+        (resources.EMPTY_STR, False, "0th and 1st grade"),
         (resources.EASY_TEXT, True, 4.0),
         (resources.EASY_TEXT, False, "3rd and 4th grade"),
         (resources.SHORT_TEXT, True, 2.0),
@@ -23,3 +24,31 @@ from ..backend import resources
 def test_text_standard(text: str, float_output: bool, expected: float | str) -> None:
     ts = type(textstat)()
     assert ts.text_standard(text, float_output) == expected
+
+
+# Test that grade level bounds are clamped (issue #205)
+VERY_SIMPLE_TEXT = "I am"
+VERY_COMPLEX_TEXT = (
+    "Epistemological paradigms invariably necessitate hermeneutic scrutiny "
+    "of phenomenological constructs through dialectical methodologies."
+)
+
+
+@pytest.mark.parametrize(
+    "text, float_output, min_expected, max_expected",
+    [
+        # Very simple text should clamp to minimum (1.0 / "0th and 1st grade")
+        (VERY_SIMPLE_TEXT, True, 1.0, 1.0),
+        (VERY_SIMPLE_TEXT, False, "0th and 1st grade", "0th and 1st grade"),
+        # Very complex text should clamp to maximum (18.0 / "17th and 18th grade")
+        (VERY_COMPLEX_TEXT, True, 18.0, 18.0),
+        (VERY_COMPLEX_TEXT, False, "17th and 18th grade", "17th and 18th grade"),
+    ],
+)
+def test_text_standard_bounds(
+    text: str, float_output: bool, min_expected: float | str, max_expected: float | str
+) -> None:
+    """Test that text_standard clamps to sensible grade level bounds."""
+    ts = type(textstat)()
+    result = ts.text_standard(text, float_output)
+    assert result == min_expected or result == max_expected

--- a/tests/textstat/test_text_standard.py
+++ b/tests/textstat/test_text_standard.py
@@ -8,7 +8,6 @@ from ..backend import resources
 @pytest.mark.parametrize(
     "text, float_output, expected",
     [
-        # Empty/simple text now clamps to minimum grade level (1.0)
         (resources.EMPTY_STR, True, 1.0),
         (resources.EMPTY_STR, False, "0th and 1st grade"),
         (resources.EASY_TEXT, True, 4.0),

--- a/tests/textstat/test_text_standard.py
+++ b/tests/textstat/test_text_standard.py
@@ -25,23 +25,20 @@ def test_text_standard(text: str, float_output: bool, expected: float | str) -> 
     assert ts.text_standard(text, float_output) == expected
 
 
-# Test that grade level bounds are clamped (issue #205)
-VERY_SIMPLE_TEXT = "I am simple"
-VERY_COMPLEX_TEXT = (
-    "Epistemological paradigms invariably necessitate hermeneutic scrutiny "
-    "of phenomenological constructs through dialectical methodologies."
-)
-
-
 @pytest.mark.parametrize(
     "text, float_output, min_expected, max_expected",
     [
         # Very simple text should clamp to minimum (1.0 / "0th and 1st grade")
-        (VERY_SIMPLE_TEXT, True, 1.0, 1.0),
-        (VERY_SIMPLE_TEXT, False, "0th and 1st grade", "0th and 1st grade"),
+        (resources.VERY_SIMPLE_TEXT, True, 1.0, 1.0),
+        (resources.VERY_SIMPLE_TEXT, False, "0th and 1st grade", "0th and 1st grade"),
         # Very complex text should clamp to maximum (18.0 / "17th and 18th grade")
-        (VERY_COMPLEX_TEXT, True, 18.0, 18.0),
-        (VERY_COMPLEX_TEXT, False, "17th and 18th grade", "17th and 18th grade"),
+        (resources.VERY_COMPLEX_TEXT, True, 18.0, 18.0),
+        (
+            resources.VERY_COMPLEX_TEXT,
+            False,
+            "17th and 18th grade",
+            "17th and 18th grade",
+        ),
     ],
 )
 def test_text_standard_bounds(

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -985,8 +985,7 @@ class textstatistics:
         down and up, respectively.
 
         The output is clamped to sensible educational grade bounds: 1-18
-        (kindergarten through graduate school). This prevents nonsensical
-        outputs like "-1th and 0th grade" for very simple text.
+        (kindergarten through graduate school).
 
         Parameters
         ----------

--- a/textstat/textstat.py
+++ b/textstat/textstat.py
@@ -984,6 +984,10 @@ class textstatistics:
         "XX and YY grade" where XX and YY are gotten by rounding the float value
         down and up, respectively.
 
+        The output is clamped to sensible educational grade bounds: 1-18
+        (kindergarten through graduate school). This prevents nonsensical
+        outputs like "-1th and 0th grade" for very simple text.
+
         Parameters
         ----------
         text : str
@@ -997,6 +1001,8 @@ class textstatistics:
             The Text Standard for `text`.
         """
         standard_value = metrics.text_standard(text, self.__lang)
+        # Clamp to sensible educational grade bounds (K through graduate school)
+        standard_value = max(1, min(standard_value, 18))
         if float_output:
             return self._legacy_round(standard_value)
         else:


### PR DESCRIPTION
## Summary

Fixes #205

## Changes

This PR clamps the ["readability-consensus"](https://github.com/textstat/textstat?tab=readme-ov-file#readability-consensus-based-upon-all-the-above-tests) score computed by `textstat.text_standard` to reasonable bounds:

- **Minimum: 1** (produces "0th and 1st grade" = Kindergarten/1st grade)
- **Maximum: 18** (produces "17th and 18th grade" = Graduate school)

The clamping is applied before both `float_output=True` and `float_output=False` cases.

## Testing

- Updated existing test expectations for empty string input (now clamps to minimum)
- Added new test cases for very simple and very complex text to verify bounds clamping
- All 450 tests pass

## Rationale for bounds

- **1 (minimum)**: Represents kindergarten/1st grade level. No educational text should be rated below this.
- **18 (maximum)**: Represents graduate school level. While some readability formulas can produce higher values for extremely complex text, grade 18 is a reasonable upper bound for practical purposes.